### PR TITLE
切换到 AKShare：支持沪深/京 + 场内基金 + 港美股索引，新增后台更新与候选式添加

### DIFF
--- a/App.py
+++ b/App.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QStyle
 from WidgetPanel import FloatLabel
 from SettingPanel import SettingsDialog
 from config_store import load_config, save_config
-from code_index import refresh_once_per_day
+from code_index import refresh_in_background_if_needed
 
 # ----- 程序与资源 -----
 APP_NAME = "StockWidget"
@@ -26,7 +26,7 @@ class App(QApplication):
         icon_path = resource_path(APP_ICON_FILE)
         # load saved icon choice from config
         cfg = load_config(APP_NAME)
-        self.code_index, cfg = refresh_once_per_day(APP_NAME, cfg)
+        self.code_index = []
         icon_choice = cfg.get('app_icon')
         self._app_icon_choice = icon_choice
         def _resolve_icon(choice):
@@ -84,7 +84,12 @@ class App(QApplication):
         self.win.raise_()
         self.win.activateWindow()
         self.win.setFocus(Qt.ActiveWindowFocusReason)
+        refresh_in_background_if_needed(APP_NAME, on_ready=self._on_code_index_ready)
         self.save_now()
+
+
+    def _on_code_index_ready(self, entries):
+        self.code_index = list(entries or [])
 
     def on_tray_activated(self, reason):
         if reason in (QSystemTrayIcon.Trigger, QSystemTrayIcon.DoubleClick): self.toggle_win()
@@ -97,6 +102,7 @@ class App(QApplication):
             self.win.raise_()
             self.win.activateWindow()
             self.win.setFocus(Qt.ActiveWindowFocusReason)
+        refresh_in_background_if_needed(APP_NAME, on_ready=self._on_code_index_ready)
         self.save_now()
 
     def open_settings(self):

--- a/SettingPanel.py
+++ b/SettingPanel.py
@@ -433,7 +433,9 @@ class SettingsDialog(QDialog):
         return None
 
     def _display_text(self, item: dict) -> str:
-        return f"{item.get('code', '')} {item.get('name', '')}".strip()
+        cat = str(item.get('category', '')).strip()
+        cat_text = f" [{cat}]" if cat else ""
+        return f"{item.get('code', '')} {item.get('name', '')}{cat_text}".strip()
 
     def _apply_suggestion(self, editor: QLineEdit, text: str):
         code = self._suggestion_map.get(text)
@@ -458,8 +460,15 @@ class SettingsDialog(QDialog):
             return None
         if s in self._suggestion_map:
             return self._suggestion_map[s]
-        token = s.split()[0]
-        return self._to_prefixed_code(token)
+
+        # 仅允许从代码列表候选中选择，不接受任意手工输入
+        code_map = {str(item.get('code', '')): item for item in (self.code_index or [])}
+        if s in code_map:
+            return s
+        token = s.split()[0].lower()
+        if token in code_map:
+            return token
+        return None
 
     def _collect_codes_from_list(self):
         codes = []
@@ -493,17 +502,17 @@ class SettingsDialog(QDialog):
         codes = self._collect_codes_from_list()
         self.win.set_codes(codes)
         checked_codes = [
-            self.list_codes.item(i).text().split()[0]
+            (self._code_from_input(self.list_codes.item(i).text()) or "")
             for i in range(self.list_codes.count())
             if self.list_codes.item(i).checkState() == Qt.Checked
         ]
         self.win.set_checked_codes(checked_codes)
 
     def _add_code(self):
-        it = QListWidgetItem("sh000001")
+        it = QListWidgetItem("")
         it.setFlags(it.flags() | Qt.ItemIsUserCheckable | Qt.ItemIsEditable | Qt.ItemIsSelectable | Qt.ItemIsEnabled)
         it.setCheckState(Qt.Unchecked)
-        it.setData(Qt.UserRole, "sh000001")
+        it.setData(Qt.UserRole, "")
         self.list_codes.addItem(it)
         self.list_codes.setCurrentItem(it)
         self.list_codes.editItem(it)

--- a/SettingPanel.py
+++ b/SettingPanel.py
@@ -463,6 +463,16 @@ class SettingsDialog(QDialog):
 
         # 仅允许从代码列表候选中选择，不接受任意手工输入
         code_map = {str(item.get('code', '')): item for item in (self.code_index or [])}
+        # 索引暂不可用时，允许保留已存在的规范代码，避免误清空自选
+        if not code_map:
+            token = s.split()[0].lower()
+            if (
+                re.match(r"^(sh|sz|bj)\d{6}$", token)
+                or re.match(r"^hk\d{5}$", token)
+                or re.match(r"^us[a-z0-9\.\-]+$", token)
+            ):
+                return token
+            return None
         if s in code_map:
             return s
         token = s.split()[0].lower()
@@ -490,8 +500,13 @@ class SettingsDialog(QDialog):
                 it = self.list_codes.item(i)
                 prev = it.data(Qt.UserRole)
                 if prev:
+                    prev_code = self._code_from_input(prev) or str(prev).strip().lower()
+                    if prev_code and prev_code not in seen:
+                        seen.add(prev_code)
+                        codes.append(prev_code)
                     self.list_codes.blockSignals(True)
-                    it.setText(prev)
+                    it.setText(prev_code if prev_code else prev)
+                    it.setData(Qt.UserRole, prev_code if prev_code else prev)
                     self.list_codes.blockSignals(False)
                 else:
                     self.list_codes.takeItem(i)
@@ -501,11 +516,19 @@ class SettingsDialog(QDialog):
     def _on_codes_changed(self, _item):
         codes = self._collect_codes_from_list()
         self.win.set_codes(codes)
-        checked_codes = [
-            (self._code_from_input(self.list_codes.item(i).text()) or "")
-            for i in range(self.list_codes.count())
-            if self.list_codes.item(i).checkState() == Qt.Checked
-        ]
+        checked_codes = []
+        for i in range(self.list_codes.count()):
+            it = self.list_codes.item(i)
+            if it.checkState() != Qt.Checked:
+                continue
+            code = self._code_from_input(it.text())
+            if not code:
+                prev = it.data(Qt.UserRole)
+                code = self._code_from_input(prev) if prev else None
+                if not code and prev:
+                    code = str(prev).strip().lower()
+            if code:
+                checked_codes.append(code)
         self.win.set_checked_codes(checked_codes)
 
     def _add_code(self):

--- a/code_index.py
+++ b/code_index.py
@@ -1,5 +1,7 @@
 import json
 import os
+import re
+import threading
 from datetime import datetime
 
 from config_store import config_paths
@@ -16,29 +18,68 @@ except Exception:
     Style = None
 
 
-def _to_prefixed_code(code: str) -> str:
+def _to_prefixed_code(code: str, board: str = "") -> str:
     code = str(code or "").strip().lower()
+    board = str(board or "").strip().lower()
     if len(code) == 8 and code[:2] in ("sh", "sz", "bj"):
         return code
     if len(code) == 6 and code.isdigit():
-        if code[0] in ("6", "5", "9"):
+        if board == "沪a" or code[0] in ("6", "5", "9"):
             return f"sh{code}"
-        if code[0] in ("0", "1", "2", "3"):
+        if board == "深a" or code[0] in ("0", "1", "2", "3"):
             return f"sz{code}"
-        if code[0] in ("4", "8"):
+        if board == "京a" or code[0] in ("4", "8"):
             return f"bj{code}"
     return code
+
+
+def _norm_hk_code(code: str) -> str:
+    raw = str(code or "").strip().lower()
+    if raw.startswith("hk"):
+        raw = raw[2:]
+    raw = "".join(ch for ch in raw if ch.isdigit())
+    if not raw:
+        return ""
+    return f"hk{raw.zfill(5)}"
+
+
+def _norm_us_code(code: str) -> str:
+    raw = str(code or "").strip().lower()
+    if raw.startswith("us"):
+        raw = raw[2:]
+    raw = raw.lstrip(".")
+    raw = raw.replace(" ", "")
+    return f"us{raw}" if raw else ""
+
+
+def _ascii_words(text: str) -> list[str]:
+    return [w.lower() for w in re.findall(r"[A-Za-z0-9]+", str(text or "")) if w]
 
 
 def _name_pinyin(name: str) -> tuple[str, str]:
     text = str(name or "").strip()
     if not text:
         return "", ""
-    if pinyin is None:
-        return "", ""
-    py_full = "".join(x[0] for x in pinyin(text, style=Style.NORMAL, strict=False))
-    py_abbr = "".join(x[0] for x in pinyin(text, style=Style.FIRST_LETTER, strict=False))
-    return py_full.lower(), py_abbr.lower()
+
+    py_full = ""
+    py_abbr = ""
+    if pinyin is not None:
+        try:
+            py_full = "".join(x[0] for x in pinyin(text, style=Style.NORMAL, strict=False)).lower()
+            py_abbr = "".join(x[0] for x in pinyin(text, style=Style.FIRST_LETTER, strict=False)).lower()
+        except Exception:
+            py_full = ""
+            py_abbr = ""
+
+    words = _ascii_words(text)
+    ascii_full = "".join(words)
+    ascii_abbr = "".join(w[0] for w in words if w)
+
+    if ascii_full and ascii_full not in py_full:
+        py_full = f"{py_full}{ascii_full}"
+    if ascii_abbr and ascii_abbr not in py_abbr:
+        py_abbr = f"{py_abbr}{ascii_abbr}"
+    return py_full, py_abbr
 
 
 def _cache_file(app_name: str) -> str:
@@ -47,62 +88,167 @@ def _cache_file(app_name: str) -> str:
     return os.path.join(cache_dir, "stock_codes_cache.json")
 
 
-def load_cached_index(app_name: str) -> list[dict]:
+def load_cached_index_meta(app_name: str) -> dict:
     path = _cache_file(app_name)
     try:
         with open(path, "r", encoding="utf-8") as file:
-            data = json.load(file)
-            return data if isinstance(data, list) else []
+            payload = json.load(file)
+            if isinstance(payload, list):
+                return {"updated_on": "", "updated_at": "", "entries": payload}
+            if isinstance(payload, dict):
+                entries = payload.get("entries", [])
+                if isinstance(entries, list):
+                    return {
+                        "updated_on": str(payload.get("updated_on", "")),
+                        "updated_at": str(payload.get("updated_at", "")),
+                        "entries": entries,
+                    }
     except Exception:
-        return []
+        pass
+    return {"updated_on": "", "updated_at": "", "entries": []}
+
+
+def load_cached_index(app_name: str) -> list[dict]:
+    return load_cached_index_meta(app_name).get("entries", [])
 
 
 def _save_cached_index(app_name: str, entries: list[dict]):
     path = _cache_file(app_name)
+    now = datetime.now()
+    payload = {
+        "updated_on": now.strftime("%Y-%m-%d"),
+        "updated_at": now.strftime("%Y-%m-%d %H:%M:%S"),
+        "entries": entries,
+    }
     tmp = f"{path}.tmp"
     with open(tmp, "w", encoding="utf-8") as file:
-        json.dump(entries, file, ensure_ascii=False)
+        json.dump(payload, file, ensure_ascii=False)
     os.replace(tmp, path)
+
+
+def _row_get(row, *keys, default=""):
+    for key in keys:
+        if key in row and str(row[key]).strip() not in ("", "nan", "None"):
+            return str(row[key]).strip()
+    return default
 
 
 def refresh_index_from_akshare(app_name: str) -> list[dict]:
     if ak is None:
         raise RuntimeError("akshare unavailable")
 
-    df = ak.stock_info_a_code_name()
-    entries = []
-    for _, row in df.iterrows():
-        code_raw = str(row.get("code", "")).strip()
-        name = str(row.get("name", "")).strip()
-        code = _to_prefixed_code(code_raw)
+    entries: list[dict] = []
+
+    def add_entry(code: str, code_num: str, name: str, category: str, market: str):
+        key = str(code or "").strip().lower()
+        if not key:
+            return
         py_full, py_abbr = _name_pinyin(name)
+        symbol_words = _ascii_words(code_num)
+        if symbol_words:
+            merged = "".join(symbol_words)
+            if merged not in py_full:
+                py_full = f"{py_full}{merged}"
+            if merged and merged[0] not in py_abbr:
+                py_abbr = f"{py_abbr}{''.join(w[0] for w in symbol_words if w)}"
         entries.append({
-            "code": code,
-            "code_num": code_raw,
-            "name": name,
+            "code": key,
+            "code_num": str(code_num or "").strip(),
+            "name": str(name or "").strip(),
             "py": py_full,
             "abbr": py_abbr,
+            "category": category,
+            "market": market,
         })
 
-    entries.sort(key=lambda item: item["code"])
-    _save_cached_index(app_name, entries)
-    return entries
+    # 沪深京 A 股 + 场内基金
+    df_a = ak.stock_info_a_code_name()
+    for _, row in df_a.iterrows():
+        code_raw = _row_get(row, "code", "代码")
+        name = _row_get(row, "name", "名称")
+        code = _to_prefixed_code(code_raw)
+        if not code:
+            continue
+        category = "沪A" if code.startswith("sh") else ("深A" if code.startswith("sz") else "京A")
+        add_entry(code, code_raw, name, category, "cn")
+
+    df_etf = ak.fund_etf_spot_em()
+    for _, row in df_etf.iterrows():
+        code_raw = _row_get(row, "代码", "code")
+        name = _row_get(row, "名称", "name")
+        code = _to_prefixed_code(code_raw)
+        if not code:
+            continue
+        category = "沪基" if code.startswith("sh") else "深基"
+        add_entry(code, code_raw, name, category, "fund")
+
+    # 港股
+    df_hk = ak.stock_hk_spot_em()
+    for _, row in df_hk.iterrows():
+        code_raw = _row_get(row, "代码", "symbol")
+        name = _row_get(row, "名称", "name")
+        code = _norm_hk_code(code_raw)
+        if code:
+            add_entry(code, code_raw, name, "港股", "hk")
+
+    # 美股
+    df_us = ak.stock_us_spot_em()
+    for _, row in df_us.iterrows():
+        code_raw = _row_get(row, "代码", "symbol")
+        name = _row_get(row, "名称", "name")
+        code = _norm_us_code(code_raw)
+        if code:
+            add_entry(code, code_raw, name, "美股", "us")
+
+    merged = {}
+    for item in entries:
+        merged[item["code"]] = item
+
+    out = sorted(merged.values(), key=lambda item: item["code"])
+    _save_cached_index(app_name, out)
+    return out
 
 
-def refresh_once_per_day(app_name: str, cfg: dict) -> tuple[list[dict], dict]:
+def is_index_updated_today(app_name: str) -> bool:
     today = datetime.now().strftime("%Y-%m-%d")
-    last_day = str(cfg.get("code_index_updated", ""))
-    entries = load_cached_index(app_name)
-    if last_day == today and entries:
-        return entries, cfg
+    return load_cached_index_meta(app_name).get("updated_on") == today
 
+
+def refresh_once_per_day(app_name: str) -> tuple[list[dict], bool]:
+    entries = load_cached_index(app_name)
+    if entries and is_index_updated_today(app_name):
+        return entries, False
     try:
         entries = refresh_index_from_akshare(app_name)
-        cfg["code_index_updated"] = today
+        return entries, True
     except Exception:
-        if not entries:
-            entries = []
-    return entries, cfg
+        return entries, False
+
+
+def refresh_in_background_if_needed(app_name: str, on_ready=None):
+    entries = load_cached_index(app_name)
+    if callable(on_ready):
+        try:
+            on_ready(entries)
+        except Exception:
+            pass
+
+    if is_index_updated_today(app_name):
+        return
+
+    def _job():
+        latest = entries
+        try:
+            latest = refresh_index_from_akshare(app_name)
+        except Exception:
+            pass
+        if callable(on_ready):
+            try:
+                on_ready(latest)
+            except Exception:
+                pass
+
+    threading.Thread(target=_job, daemon=True).start()
 
 
 def find_suggestions(entries: list[dict], text: str, limit: int = 20) -> list[dict]:
@@ -112,19 +258,21 @@ def find_suggestions(entries: list[dict], text: str, limit: int = 20) -> list[di
 
     scored = []
     for item in entries:
-        code = item.get("code", "")
-        code_num = item.get("code_num", "")
+        code = str(item.get("code", "")).lower()
+        code_num = str(item.get("code_num", "")).lower()
         name = str(item.get("name", ""))
-        py = str(item.get("py", ""))
-        abbr = str(item.get("abbr", ""))
+        name_l = name.lower()
+        py = str(item.get("py", "")).lower()
+        abbr = str(item.get("abbr", "")).lower()
+        cat = str(item.get("category", "")).lower()
         score = 0
         if code.startswith(q) or code_num.startswith(q):
             score = 100
         elif q in code or q in code_num:
             score = 85
-        elif name.startswith(q):
+        elif name_l.startswith(q):
             score = 70
-        elif q in name:
+        elif q in name_l:
             score = 60
         elif py.startswith(q):
             score = 50
@@ -134,6 +282,8 @@ def find_suggestions(entries: list[dict], text: str, limit: int = 20) -> list[di
             score = 30
         elif q in abbr:
             score = 20
+        elif q in cat:
+            score = 10
 
         if score > 0:
             scored.append((score, item))

--- a/stock_data.py
+++ b/stock_data.py
@@ -1,9 +1,14 @@
-import requests
+from typing import Any
+
+try:
+    import akshare as ak
+except Exception:
+    ak = None
 
 
 def _format_volume(value: float) -> str:
     if value < 1e4:
-        return f"{value}"
+        return f"{value:.0f}"
     if value < 1e8:
         return f"{value / 1e4:.2f}万"
     return f"{value / 1e8:.2f}亿"
@@ -17,147 +22,178 @@ def _format_amount(value: float) -> str:
     return f"{value / 1e12:.2f}万亿"
 
 
+def _to_float(v: Any, default: float = 0.0) -> float:
+    try:
+        text = str(v).replace(",", "").replace("%", "").strip()
+        return float(text)
+    except Exception:
+        return default
+
+
+def _first_value(row: dict, *keys: str, default: float = 0.0) -> float:
+    for key in keys:
+        if key in row:
+            value = _to_float(row.get(key), default=float("nan"))
+            if value == value:
+                return value
+    return default
+
+
+def _index_by_code(df, code_keys: tuple[str, ...], normalize) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for _, row in df.iterrows():
+        data = row.to_dict()
+        raw = ""
+        for key in code_keys:
+            if key in data and str(data.get(key, "")).strip():
+                raw = str(data.get(key)).strip()
+                break
+        if not raw:
+            continue
+        code = normalize(raw)
+        if code:
+            out[code] = data
+    return out
+
+
+def _norm_cn(code: str) -> str:
+    text = str(code or "").strip().lower()
+    if len(text) == 8 and text[:2] in ("sh", "sz", "bj"):
+        return text
+    if len(text) == 6 and text.isdigit():
+        if text[0] in ("6", "5", "9"):
+            return f"sh{text}"
+        if text[0] in ("0", "1", "2", "3"):
+            return f"sz{text}"
+        if text[0] in ("4", "8"):
+            return f"bj{text}"
+    return text
+
+
+def _norm_hk(code: str) -> str:
+    text = str(code or "").strip().lower()
+    if text.startswith("hk"):
+        text = text[2:]
+    digits = "".join(ch for ch in text if ch.isdigit())
+    return f"hk{digits.zfill(5)}" if digits else ""
+
+
+def _norm_us(code: str) -> str:
+    text = str(code or "").strip().lower()
+    if text.startswith("us"):
+        text = text[2:]
+    text = text.lstrip(".").replace(" ", "")
+    return f"us{text}" if text else ""
+
+
+def _fetch_market_snapshots() -> dict[str, dict[str, dict]]:
+    if ak is None:
+        raise RuntimeError("akshare unavailable")
+
+    cn = _index_by_code(ak.stock_zh_a_spot_em(), ("代码", "code"), _norm_cn)
+    fund = _index_by_code(ak.fund_etf_spot_em(), ("代码", "code"), _norm_cn)
+    hk = _index_by_code(ak.stock_hk_spot_em(), ("代码", "symbol"), _norm_hk)
+    us = _index_by_code(ak.stock_us_spot_em(), ("代码", "symbol"), _norm_us)
+    return {"cn": cn, "fund": fund, "hk": hk, "us": us}
+
+
+def _row_from_quote(code: str, row: dict, short_code: bool, name_length: int):
+    name = str(row.get("名称") or row.get("name") or row.get("股票名称") or "").strip()
+    category = "沪A" if code.startswith("sh") else "深A"
+    precision = 2
+    if code.startswith("bj"):
+        category = "京A"
+    elif code.startswith("hk"):
+        category = "港股"
+    elif code.startswith("us"):
+        category = "美股"
+    elif code.startswith(("sh5", "sz1")):
+        category = "基金"
+        precision = 3
+
+    current_price = _first_value(row, "最新价", "最新", "现价", "最新价(美元)")
+    prev_close = _first_value(row, "昨收", "昨收价", "昨收盘")
+    opening_price = _first_value(row, "今开", "开盘")
+    high_price = _first_value(row, "最高", "最高价")
+    low_price = _first_value(row, "最低", "最低价")
+    change = _first_value(row, "涨跌额", "涨跌")
+    change_pct = _first_value(row, "涨跌幅")
+    deals_vol = _first_value(row, "成交量", "成交量(手)")
+    deals_amt = _first_value(row, "成交额", "成交金额")
+
+    if prev_close <= 0 and current_price and change:
+        prev_close = current_price - change
+    if change == 0 and current_price and prev_close:
+        change = current_price - prev_close
+    if change_pct == 0 and prev_close:
+        change_pct = (current_price / prev_close - 1) * 100 if prev_close else 0
+
+    if current_price == 0:
+        current_price = prev_close
+    if opening_price == 0:
+        opening_price = current_price
+    if high_price == 0:
+        high_price = current_price
+    if low_price == 0:
+        low_price = current_price
+
+    avg = (deals_amt / deals_vol) if deals_vol > 0 else prev_close
+    arrow = " "
+    if high_price > low_price:
+        if abs(current_price - high_price) < 10 ** (-precision):
+            arrow = "↑"
+        elif abs(current_price - low_price) < 10 ** (-precision):
+            arrow = "↓"
+
+    value_prefix = code[2:] if short_code and code[:2] in ("sh", "sz", "bj", "hk", "us") else code
+    name_prefix = name if name_length == 0 else name[:name_length]
+    label_name = f"{name_prefix} [{category}]" if category else name_prefix
+
+    return [
+        value_prefix,
+        label_name,
+        f"{current_price:.{precision}f}{arrow}",
+        f"{change:+.{precision}f}",
+        f"{change_pct:+.2f}%",
+        "-",
+        "-",
+        "-",
+        _format_volume(deals_vol),
+        _format_amount(deals_amt),
+        f"{avg:.{precision}f}",
+        {"k": (opening_price, current_price, high_price, low_price, prev_close)},
+    ], {
+        "delta": (change > 0) - (change < 0),
+        "commi": 0,
+        "avg": (avg > prev_close) - (avg < prev_close),
+        "b1": 0,
+        "s1": 0,
+    }
+
+
 def fetch_stock_rows(codes: list[str], short_code: bool, name_length: int, b1s1_display: str):
-    label = ",".join([str(c).strip() for c in codes if str(c).strip()])
-    if not label:
+    _ = b1s1_display
+    symbols = [str(c).strip().lower() for c in codes if str(c).strip()]
+    if not symbols:
         raise Exception("暂无数据，请添加自选")
+
+    snapshots = _fetch_market_snapshots()
+    combined = {}
+    combined.update(snapshots["cn"])
+    combined.update(snapshots["fund"])
+    combined.update(snapshots["hk"])
+    combined.update(snapshots["us"])
 
     price_data = []
     sign_data = []
-    url = "https://hq.sinajs.cn/list=" + label
-    headers = {"Referer": "https://finance.sina.com.cn", "User-Agent": "Mozilla/5.0"}
-    response = requests.get(url, headers=headers, timeout=3)
-    response.encoding = "gbk"
-    for line in response.text.split("\n"):
-        if not line or '"' not in line:
+    for code in symbols:
+        row = combined.get(code)
+        if not row:
             continue
-        heads = line.split('="')[0].split("_")
-        parts = line.split('="')[1].split(",")
-        if len(parts) < 30:
-            continue
+        one_row, one_sign = _row_from_quote(code, row, short_code, name_length)
+        price_data.append(one_row)
+        sign_data.append(one_sign)
 
-        code = heads[2]
-        name = parts[0]
-        opening_price = float(parts[1] or 0)
-        prev_close = float(parts[2] or 0)
-        current_price = float(parts[3] or 0)
-        high_price = float(parts[4] or 0)
-        low_price = float(parts[5] or 0)
-        first_pur = float(parts[6] or 0)
-        first_sell = float(parts[7] or 0)
-        deals_vol = float(parts[8] or 0)
-        deals_amt = float(parts[9] or 0)
-        purchaser = [int(x or 0) for x in parts[10:19:2]]
-        seller = [int(x or 0) for x in parts[20:29:2]]
-        etf = code[2] in ("1", "5")
-
-        b1_label = ""
-        s1_label = ""
-        b1_color_sign = 0
-        s1_color_sign = 0
-
-        dec = 3 if etf else 2
-
-        def almost_eq(a, b):
-            try:
-                return round(float(a), dec) == round(float(b), dec)
-            except Exception:
-                return False
-
-        buy_marker = "<" if first_pur > 0 and almost_eq(current_price, first_pur) else " "
-        sell_marker = ">" if first_sell > 0 and almost_eq(current_price, first_sell) else " "
-
-        if first_pur == first_sell > 0:
-            current_price = first_sell
-            paired = seller[0]
-            unpaired_sign = -seller[1] if seller[1] > 0 else purchaser[1]
-            paired_cnt = int(paired / 100)
-            unpaired_cnt = int(unpaired_sign / 100)
-            b_price = f"{first_pur:.3f}" if etf else f"{first_pur:.2f}"
-            s_price = f"{first_sell:.3f}" if etf else f"{first_sell:.2f}"
-            if b1s1_display == "price":
-                b1_label = b_price
-                s1_label = s_price
-            elif b1s1_display == "both":
-                b1_label = f"{paired_cnt:d}({b_price})"
-                s1_label = f"{unpaired_cnt:+d}({s_price})"
-            else:
-                b1_label = f"{paired_cnt:d}"
-                s1_label = f"{unpaired_cnt:+d}"
-            b1_color_sign = (unpaired_sign > 0) - (unpaired_sign < 0)
-            s1_color_sign = b1_color_sign
-        else:
-            if first_pur > 0:
-                cnt = f"{int(purchaser[0] / 100)}"
-                b_price = f"{first_pur:.3f}" if etf else f"{first_pur:.2f}"
-                if b1s1_display == "price":
-                    b1_label = f"{b_price}{buy_marker}"
-                elif b1s1_display == "both":
-                    b1_label = f"{cnt}({b_price}){buy_marker}"
-                else:
-                    b1_label = f"{cnt}{buy_marker}"
-            else:
-                b1_label = f"-{buy_marker}"
-
-            if first_sell > 0:
-                cnt = f"{int(seller[0] / 100)}"
-                s_price = f"{first_sell:.3f}" if etf else f"{first_sell:.2f}"
-                if b1s1_display == "price":
-                    s1_label = f"{sell_marker}{s_price}"
-                elif b1s1_display == "both":
-                    s1_label = f"{sell_marker}{cnt}({s_price})"
-                else:
-                    s1_label = f"{sell_marker}{cnt}"
-            else:
-                s1_label = f"{sell_marker}-"
-            b1_color_sign = 1
-            s1_color_sign = -1
-
-        if current_price == 0:
-            current_price = prev_close
-        if opening_price == 0:
-            opening_price = current_price
-            high_price = current_price
-            low_price = current_price
-
-        change = current_price - prev_close if prev_close else 0.0
-        change_pct = (current_price / prev_close - 1) * 100 if prev_close else 0.0
-        avg = (deals_amt / deals_vol) if deals_vol > 0 else prev_close
-        p_sum, s_sum = sum(purchaser), sum(seller)
-        committee = (100 * (p_sum - s_sum) / (p_sum + s_sum)) if (p_sum + s_sum) > 0 else 0.0
-
-        arrow = " "
-        if high_price > low_price:
-            if current_price == high_price:
-                arrow = "↑"
-            elif current_price == low_price:
-                arrow = "↓"
-
-        k_payload = {"k": (opening_price, current_price, high_price, low_price, prev_close)}
-        precision = 3 if etf else 2
-        value_prefix = code[2:] if short_code else code
-        name_prefix = name if name_length == 0 else name[:name_length]
-        price_data.append([
-            value_prefix,
-            name_prefix,
-            f"{current_price:.{precision}f}{arrow}",
-            f"{change:+.{precision}f}",
-            f"{change_pct:+.2f}%",
-            b1_label,
-            s1_label,
-            f"{committee:+.2f}%",
-            _format_volume(deals_vol),
-            _format_amount(deals_amt),
-            f"{avg:.{precision}f}",
-            k_payload,
-        ])
-
-        sign_data.append({
-            "delta": (change > 0) - (change < 0),
-            "commi": (committee > 0) - (committee < 0),
-            "avg": (avg > prev_close) - (avg < prev_close),
-            "b1": b1_color_sign,
-            "s1": s1_color_sign,
-        })
-
+    if not price_data:
+        raise Exception("所选代码暂无可用行情")
     return price_data, sign_data


### PR DESCRIPTION
### Motivation
- 将行情数据源从新浪接口替换为 `akshare` 以获得对 A 股、场内基金、港股和美股的统一支持并增强兼容性。 
- 在索引缓存中记录更新时间以避免应用启动时重复抓取并支持后台更新。 
- 修复原有索引在拼音/缩写/英文名匹配上的不完整性，并在设置候选中暴露市场/类别信息。 
- 为避免误输入，将“添加股票代码”改为仅能从候选列表选择（不再接受任意自定义输入）。

### Description
- 将行情拉取逻辑移入 `stock_data.py`，改为使用 `akshare` 的快照接口并统一组合 `A 股`、`场内基金`、`港股` 与 `美股` 数据，新增多市场代码标准化函数如 `_norm_hk`、`_norm_us`、`_norm_cn`。 
- 重构代码索引实现 `code_index.py`：新增 `_save_cached_index` 输出包含 `updated_on`/`updated_at` 的 JSON 结构，增强拼音/缩写构造逻辑（包含英文/代码词元），并扩展条目字段为 `{code, code_num, name, py, abbr, category, market}`。 
- 增加后台更新入口 `refresh_in_background_if_needed(app_name, on_ready)`，并调整为在启动后立即显示浮窗同时异步刷新索引（通过回调 `on_ready` 更新内存中的 `code_index`）。 
- 修改设置界面 `SettingPanel.py`：候选展示通过 `code + name + [category]`；`_code_from_input` 仅接受来自候选列表或候选代码的选择；新增空默认新行以避免自动插入固定代码。 
- 兼容性与占位：原先基于新浪的买一/卖一/委比解析被替换为统一表格占位/计算（多市场下部分字段保持占位 `-`），`fetch_stock_rows` 输出格式保持原表格列结构以最小化 UI 改动。 
- 影响文件：`stock_data.py`、`code_index.py`、`App.py`（启动时触发后台更新回调）与 `SettingPanel.py`（候选/添加/勾选逻辑修改）。

### Testing
- 运行语法检查 `python -m compileall .`，所有修改通过了字节码编译（语法检查）且无编译错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0822b32f483249af82c198ee47291)